### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 This project provides a Model Context Protocol (MCP) server for interacting with a Wolfram Mathematica kernel. It allows Large Language Models (LLMs) to execute Wolfram Language code in a secure, session-based environment.
 
-The `animalid` folder contains a simple tool for generating unique, animal-based identifiers. Since LLMs often fail to copy UUIDs correctly, this tool replaces them with animal-themed IDs that are more likely to be transcribed accurately.
+<a href="https://glama.ai/mcp/servers/@aac6fef/mathematica_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aac6fef/mathematica_mcp/badge" alt="Mathematica Server MCP server" />
+</a>
 
+The `animalid` folder contains a simple tool for generating unique, animal-based identifiers. Since LLMs often fail to copy UUIDs correctly, this tool replaces them with animal-themed IDs that are more likely to be transcribed accurately.
 
 ## Tools Provided
 


### PR DESCRIPTION
This PR adds a badge for the [Mathematica MCP Server](https://glama.ai/mcp/servers/@aac6fef/mathematica_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@aac6fef/mathematica_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aac6fef/mathematica_mcp/badge" alt="Mathematica Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.